### PR TITLE
TeX mode: use opening quotation mark after tilde

### DIFF
--- a/lib/texcom.sl
+++ b/lib/texcom.sl
@@ -181,7 +181,7 @@ define tex_insert_quote ()
 	return;
      }
 
-   if (is_substr("[({\t ", char(c)))
+   if (is_substr("[({\t ~", char(c)))
      {
 	insert_char ('`');
 	if (LAST_CHAR == '"') insert_char ('`');


### PR DESCRIPTION
In TeX, the tilde inserts a non-breaking space. Since a non-breaking space is a space, a quotation mark inserted right after a tilde should be an opening quotation mark, as in `the letter~``A''`. Currently, the TeX mode inserts a closing quotation mark in such a situation. This tiny patch treats tildes like spaces when it comes to inserting quotes. It does not try to determine whether the `~` is actually part of a literal tilde `\~`. I believe the effort would not be worth it because a literal tilde will hardly appear right before a quotation mark in practice.